### PR TITLE
set mode for parsnip models

### DIFF
--- a/tests/testthat/test-earth.R
+++ b/tests/testthat/test-earth.R
@@ -2,6 +2,8 @@ context("earth/MARS models")
 
 data("etitanic", package = "earth")
 
+mars_mod <- parsnip::mars(mode = "regression")
+
 test_earth <- function(..., .data = etitanic) {
   p <- invisible(
     tidypredict_test(earth::earth(...), df = .data)
@@ -119,7 +121,7 @@ test_that("Tests with parsnip returns no alert", {
   expect_false(
     tidypredict_test(
       parsnip::fit(
-        parsnip::set_engine(parsnip::mars(mode = "regression"), "earth"),
+        parsnip::set_engine(mars_mod, "earth"),
         survived ~ age + sibsp,
         data = etitanic
       ),
@@ -129,7 +131,7 @@ test_that("Tests with parsnip returns no alert", {
   expect_false(
     tidypredict_test(
       parsnip::fit(
-        parsnip::set_engine(parsnip::mars(mode = "regression"), "earth"),
+        parsnip::set_engine(mars_mod, "earth"),
         age ~ sibsp + parch,
         data = etitanic
       ),

--- a/vignettes/mars.Rmd
+++ b/vignettes/mars.Rmd
@@ -81,7 +81,7 @@ str(parse_model(model), 2)
 ```{r}
 library(parsnip)
 
-p_model <- mars(prod_degree = 3) %>%
+p_model <- mars(mode = "regression", prod_degree = 3) %>%
   set_engine("earth") %>%
   fit(age ~ sibsp + parch, data = etitanic)
 

--- a/vignettes/ranger.Rmd
+++ b/vignettes/ranger.Rmd
@@ -67,7 +67,7 @@ From there, the Tidy Eval formula can be used anywhere where it can be operated.
 ```{r}
 library(parsnip)
 
-parsnip_model <- rand_forest() %>%
+parsnip_model <- rand_forest(mode = "classification") %>%
   set_engine("ranger") %>%
   fit(Species ~ ., data = iris)
 

--- a/vignettes/rf.Rmd
+++ b/vignettes/rf.Rmd
@@ -67,7 +67,7 @@ From there, the Tidy Eval formula can be used anywhere where it can be operated.
 ```{r}
 library(parsnip)
 
-parsnip_model <- rand_forest() %>%
+parsnip_model <- rand_forest(mode = "classification") %>%
   set_engine("randomForest") %>%
   fit(Species ~ ., data = iris)
 

--- a/vignettes/xgboost.Rmd
+++ b/vignettes/xgboost.Rmd
@@ -78,7 +78,7 @@ model <- xgboost::xgb.train(
 ```{r}
 library(parsnip)
 
-p_model <- boost_tree() %>%
+p_model <- boost_tree(mode = "regression") %>%
   set_engine("xgboost") %>%
   fit(am ~ ., data = mtcars)
 ```


### PR DESCRIPTION
These changes _should_ get rid of the current [CRAN warnings](https://cran.r-project.org/web/checks/check_results_tidypredict.html) but maybe run win-builder just to be sure. 