### PR TITLE
add count:poisson and reg:tweedie to build_fit_formula_xgb()

### DIFF
--- a/R/model-xgboost.R
+++ b/R/model-xgboost.R
@@ -141,9 +141,16 @@ build_fit_formula_xgb <- function(parsedmodel) {
   } else if (objective %in% c("binary:logistic", "reg:logistic")) {
     assigned <- 1
     f <- expr(1 - 1 / (1 + exp(!!f)))
+  } else if (objective %in% c("count:poisson")) {
+    assigned <- 1
+    f <- expr(exp(!!f))
+  } else if (objective %in% c("reg:tweedie")) {
+    assigned <- 1
+    f <- expr(0.5 * exp(!!f)) ## I'm not sure why one has to multiply by 0.5, but it works.
+  
   }
   if (assigned == 0) {
-    stop("Only objectives 'binary:logistic', 'reg:linear', 'reg:logistic', 'binary:logitraw' are supported yet.")
+    stop("Only objectives 'binary:logistic', 'reg:linear', 'reg:logistic', 'binary:logitraw', 'count:poisson','reg:tweedie'  are supported yet.")
   }
   f
 }


### PR DESCRIPTION
This pull requests adds support for count:poisson and reg:tweedie, fixing  issue 62   (https://github.com/tidymodels/tidypredict/issues/62)