### PR TITLE
Fixes #76

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidypredict (development version)
 
+- Fixed parenthesis issue in the creation of the interval formula (#76)
+
 - Fixed bug in SQL query generation for XGBoost models with objective `binary:logistic`.
 
 - Re-licensed package from GPL-3 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/tidypredict/issues/95).

--- a/R/model-lm.R
+++ b/R/model-lm.R
@@ -212,16 +212,16 @@ get_qr_lm <- function(qr_name, parsedmodel) {
     q[!map_lgl(q, is.null)],
     function(x, y) expr(!!x + !!y)
   )
-  expr((!!f) * (!!f) * !!parsedmodel$general$sigma2)
+  expr(((!!f)) * ((!!f)) * !!parsedmodel$general$sigma2)
 }
 
 te_interval_lm <- function(parsedmodel, interval = 0.95) {
   qr_names <- names(parsedmodel$terms[[1]]$qr)
-  qrs <- map(
+  qrs_map <- map(
     qr_names,
     ~ get_qr_lm(.x, parsedmodel)
   )
-  qrs <- reduce(qrs, function(x, y) expr(!!x + (!!y)))
+  qrs <- reduce(qrs_map, function(x, y) expr(!!x + (!!y)))
   tfrac <- qt(1 - (1 - 0.95) / 2, parsedmodel$general$residual)
   expr(!!tfrac * sqrt((!!qrs) + (!!parsedmodel$general$sigma2)))
 }


### PR DESCRIPTION
Fixes #76 

Confirmed that the SQL translation contains the parenthesis:

```
library(tidypredict)
model <- lm(speed ~ dist, data = cars)
tidypredict_interval(model)
#> 2.01063475762423 * sqrt((-0.14142135623731) * (-0.14142135623731) * 
#>     9.95877600752493 + (-0.238267300089029 + dist * 0.0055436784571668) * 
#>     (-0.238267300089029 + dist * 0.0055436784571668) * 9.95877600752493 + 
#>     9.95877600752493)
tidypredict_sql_interval(model, con = dbplyr::simulate_dbi())
#> <SQL> 2.01063475762423 * SQRT((-0.14142135623731) * (-0.14142135623731) * 9.95877600752493 + (-0.238267300089029 + `dist` * 0.0055436784571668) * (-0.238267300089029 + `dist` * 0.0055436784571668) * 9.95877600752493 + 9.95877600752493)
```

Also confirmed that the upper and lower bounds matched when calculated inside R, and when calculated inside the database.  That was not the case before:

```
library(dplyr)
library(RSQLite)
library(DBI)

con <- dbConnect(RSQLite::SQLite(), ":memory:")
dbWriteTable(con, "cars", cars)

local_preds <- predict(model, newdata = cars, interval = "prediction")

head(local_preds)
#>         fit      lwr      upr
#> 1  8.615041 2.046715 15.18337
#> 2  9.939581 3.427222 16.45194
#> 3  8.946176 2.392929 15.49942
#> 4 11.926392 5.475837 18.37695
#> 5 10.932987 4.454892 17.41108
#> 6  9.939581 3.427222 16.45194

tbl(con, "cars") %>% 
  tidypredict_to_column(model, add_interval = TRUE) %>% 
  collect() %>% 
  as.data.frame() %>% 
  head()
#>   speed dist       fit    upper    lower
#> 1     4    2  8.615041 15.18337 2.046715
#> 2     4   10  9.939581 16.45194 3.427222
#> 3     7    4  8.946176 15.49942 2.392929
#> 4     7   22 11.926392 18.37695 5.475837
#> 5     8   16 10.932987 17.41108 4.454892
#> 6     9   10  9.939581 16.45194 3.427222
```