### PR TITLE
Adds ability to handle single committee and single rule Cubist models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidypredict (development version)
 
+- Adds capability to handle single simple Cubist models (#57)
+
 - Fixed bug in SQL query generation for XGBoost models with objective `binary:logistic`.
 
 - Re-licensed package from GPL-3 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/tidypredict/issues/95).

--- a/R/model-cubist.R
+++ b/R/model-cubist.R
@@ -3,7 +3,7 @@ parse_model.cubist <- function(model) {
   coefs <- model$coefficients
   splits <- model$splits
   splits$variable <- as.character(splits$variable)
-  splits$dir <- as.character(splits$dir)
+  splits$dir <- as.character(splits$dir)  
 
   committees2 <- map(
     unique(coefs$committee),
@@ -13,17 +13,21 @@ parse_model.cubist <- function(model) {
         coefs$rule[coefs$committee == comm],
         ~ {
           cc <- coefs[coefs$rule == .x & coefs$committee == comm, ]
-          cs <- splits[splits$rule == .x & splits$committee == comm, ]
-          tcs <- transpose(cs)
-          mcs <- map(
-            tcs,
-            ~ list(
-              type = "conditional",
-              col = .x$variable,
-              val = .x$value,
-              op = ifelse(.x$dir == ">", "more-equal", "less")
+          if(!is.null(model$splits)) {
+            cs <- splits[splits$rule == .x & splits$committee == comm, ]
+            tcs <- transpose(cs)
+            mcs <- map(
+              tcs,
+              ~ list(
+                type = "conditional",
+                col = .x$variable,
+                val = .x$value,
+                op = ifelse(.x$dir == ">", "more-equal", "less")
+              )
             )
-          )
+          } else {
+            mcs <- list(list(type = "all"))
+          }
           cc_names <- names(cc)
           f_coefs <- map(
             seq_along(cc_names),

--- a/R/model-rf.R
+++ b/R/model-rf.R
@@ -70,25 +70,30 @@ parse_model.randomForest <- function(model) {
 
 get_rf_case <- function(path, prediction, calc_mode = "") {
   
-  cl <- map(
-    path,
-    ~ {
-      i <- NULL
-      if(.x$type == "conditional") {
-        if (.x$op == "more") i <- expr(!!sym(.x$col) > !!.x$val)
-        if (.x$op == "more-equal") i <- expr(!!sym(.x$col) >= !!.x$val)
-        if (.x$op == "less") i <- expr(!!sym(.x$col) < !!.x$val)
-        if (.x$op == "less-equal") i <- expr(!!sym(.x$col) <= !!.x$val)
+  if(length(path) == 1 & path[[1]]$type == "all") {
+    rcl <- NULL
+  } else {
+    cl <- map(
+      path,
+      ~ {
+        i <- NULL
+        if(.x$type == "conditional") {
+          if (.x$op == "more") i <- expr(!!sym(.x$col) > !!.x$val)
+          if (.x$op == "more-equal") i <- expr(!!sym(.x$col) >= !!.x$val)
+          if (.x$op == "less") i <- expr(!!sym(.x$col) < !!.x$val)
+          if (.x$op == "less-equal") i <- expr(!!sym(.x$col) <= !!.x$val)
+        }
+        if(.x$type == "set") {
+          sets <- reduce(.x$vals, c)
+          if (.x$op == "in") i <- expr(!!sym(.x$col) %in% !! sets)
+          if (.x$op == "not-in") i <- expr((!!sym(.x$col) %in% !! sets) == FALSE)
+        }
+        i
       }
-      if(.x$type == "set") {
-        sets <- reduce(.x$vals, c)
-        if (.x$op == "in") i <- expr(!!sym(.x$col) %in% !! sets)
-        if (.x$op == "not-in") i <- expr((!!sym(.x$col) %in% !! sets) == FALSE)
-      }
-      i
-    }
-  )
-  cl <- reduce(cl, function(x, y) expr(!!x & !!y))
+    )
+    rcl <- reduce(cl, function(x, y) expr(!!x & !!y))
+  }
+
   if (length(prediction) > 1) {
     pl <- map(
       prediction,
@@ -103,8 +108,9 @@ get_rf_case <- function(path, prediction, calc_mode = "") {
     pl <- prediction
   }
   f <- NULL
-  if (calc_mode == "ifelse") f <- expr(ifelse(!!cl, !!pl, 0))
-  if (is.null(f)) f <- expr(!!cl ~ !!pl)
+  if(is.null(rcl)) f <- pl
+  if (is.null(f) & calc_mode == "ifelse") f <- expr(ifelse(!!rcl, !!pl, 0))
+  if (is.null(f)) f <- expr(!!rcl ~ !!pl)
   f
 }
 
@@ -125,7 +131,7 @@ build_fit_formula_rf <- function(parsedmodel) {
 
   if (calc_mode == "ifelse") {
     f <- reduce(get_rf_case_tree(1, parsedmodel), function(x, y) expr(!!x + !!y))
-    f <- expr(!!f / !!divisor)
+    if(divisor > 1) f <- expr(!!f / !!divisor)
   }
 
   if (is.null(f)) {

--- a/R/model-rf.R
+++ b/R/model-rf.R
@@ -66,10 +66,7 @@ parse_model.randomForest <- function(model) {
   as_parsed_model(pm)
 }
 
-# Fit model -----------------------------------------------
-
-get_rf_case <- function(path, prediction, calc_mode = "") {
-  
+path_formulas <- function(path) {
   if(length(path) == 1 & path[[1]]$type == "all") {
     rcl <- NULL
   } else {
@@ -93,6 +90,14 @@ get_rf_case <- function(path, prediction, calc_mode = "") {
     )
     rcl <- reduce(cl, function(x, y) expr(!!x & !!y))
   }
+  rcl
+}
+
+# Fit model -----------------------------------------------
+
+get_rf_case <- function(path, prediction, calc_mode = "") {
+  
+  rcl <- path_formulas(path)
 
   if (length(prediction) > 1) {
     pl <- map(
@@ -108,7 +113,7 @@ get_rf_case <- function(path, prediction, calc_mode = "") {
     pl <- prediction
   }
   f <- NULL
-  if(is.null(rcl)) f <- pl
+  if (is.null(rcl)) f <- pl
   if (is.null(f) & calc_mode == "ifelse") f <- expr(ifelse(!!rcl, !!pl, 0))
   if (is.null(f)) f <- expr(!!rcl ~ !!pl)
   f


### PR DESCRIPTION
Fixes #57 

``` r
library(tidypredict)
library(Cubist)
#> Loading required package: lattice
mod <-
  structure(
    list(
      data = "15\\.5,8,318.0,150,2.76,3.520,16.87,0,0,3,2\n15\\.5,8,318.0,150,2.76,3.520,16.87,0,0,3,2\n27\\.3,4,79.0,66,4.08,1.935,18.90,1,1,4,1\n21\\.4,6,258.0,110,3.08,3.215,19.44,1,0,3,1\n21,6,160.0,110,3.90,2.875,17.02,0,1,4,4\n21,6,160.0,110,3.90,2.620,16.46,0,1,4,4\n15\\.8,8,351.0,264,4.22,3.170,14.50,0,1,5,4\n14\\.7,8,440.0,230,3.23,5.345,17.42,0,0,3,4\n10\\.4,8,460.0,215,3.00,5.424,17.82,0,0,3,4\n15\\.2,8,275.8,180,3.07,3.780,18.00,0,0,3,3\n14\\.7,8,440.0,230,3.23,5.345,17.42,0,0,3,4\n18\\.1,6,225.0,105,2.76,3.460,20.22,1,0,3,1\n22\\.8,4,140.8,95,3.92,3.150,22.90,1,0,4,2\n21,6,160.0,110,3.90,2.620,16.46,0,1,4,4\n15,8,301.0,335,3.54,3.570,14.60,0,1,5,8\n21\\.4,4,121.0,109,4.11,2.780,18.60,1,1,4,2\n18\\.1,6,225.0,105,2.76,3.460,20.22,1,0,3,1\n10\\.4,8,460.0,215,3.00,5.424,17.82,0,0,3,4\n13\\.3,8,350.0,245,3.73,3.840,15.41,0,0,3,4\n14\\.7,8,440.0,230,3.23,5.345,17.42,0,0,3,4\n15\\.8,8,351.0,264,4.22,3.170,14.50,0,1,5,4\n26,4,120.3,91,4.43,2.140,16.70,0,1,5,2\n16\\.4,8,275.8,180,3.07,4.070,17.40,0,0,3,3\n22\\.8,4,108.0,93,3.85,2.320,18.61,1,1,4,1\n21\\.4,4,121.0,109,4.11,2.780,18.60,1,1,4,2\n19\\.7,6,145.0,175,3.62,2.770,15.50,0,1,5,6\n15\\.8,8,351.0,264,4.22,3.170,14.50,0,1,5,4\n15\\.2,8,304.0,150,3.15,3.435,17.30,0,0,3,2\n26,4,120.3,91,4.43,2.140,16.70,0,1,5,2\n17\\.3,8,275.8,180,3.07,3.730,17.60,0,0,3,3\n21\\.4,4,121.0,109,4.11,2.780,18.60,1,1,4,2\n22\\.8,4,108.0,93,3.85,2.320,18.61,1,1,4,1",
      names = "| Generated using R version 3.6.0 (2019-04-26)\n| on Mon Jul 15 20:36:50 2019\noutcome.\n\noutcome: continuous.\ncyl: continuous.\ndisp: continuous.\nhp: continuous.\ndrat: continuous.\nwt: continuous.\nqsec: continuous.\nvs: continuous.\nam: continuous.\ngear: continuous.\ncarb: continuous.\n",
      caseWeights = FALSE,
      model = "id=\"Cubist 2.07 GPL Edition 2019-07-15\"\nprec=\"1\" globalmean=\"18.37188\" extrap=\"1\" insts=\"0\" ceiling=\"44.2\" floor=\"0\"\natt=\"outcome\" mean=\"18.37\" sd=\"4.326829\" min=\"10.4\" max=\"27.3\"\natt=\"cyl\" mean=\"6.4\" sd=\"1.740181\" min=\"4\" max=\"8\"\natt=\"disp\" mean=\"252.61\" sd=\"121.1964\" min=\"79\" max=\"460\"\natt=\"hp\" mean=\"161.3\" sd=\"69.12569\" min=\"66\" max=\"335\"\natt=\"drat\" mean=\"3.572\" sd=\"0.5478398\" min=\"2.76\" max=\"4.43\"\natt=\"wt\" mean=\"3.4132\" sd=\"1.007245\" min=\"1.935\" max=\"5.424\"\natt=\"qsec\" mean=\"17.468\" sd=\"1.836215\" min=\"14.5\" max=\"22.9\"\natt=\"vs\" mean=\"0.3\" sd=\"0.4709301\" min=\"0\" max=\"1\"\natt=\"am\" mean=\"0.5\" sd=\"0.5080015\" min=\"0\" max=\"1\"\natt=\"gear\" mean=\"3.7\" sd=\"0.8032203\" min=\"3\" max=\"5\"\natt=\"carb\" mean=\"2.9\" sd=\"1.596052\" min=\"1\" max=\"8\"\nentries=\"1\"\nrules=\"1\"\nconds=\"0\" cover=\"32\" mean=\"18.37\" loval=\"10.4\" hival=\"27.3\" esterr=\"1.46\"\ncoeff=\"20.52\" att=\"disp\" coeff=\"-0.0294\" att=\"drat\" coeff=\"1.33\"\n",
      output = "\nCubist [Release 2.07 GPL Edition]  Mon Jul 15 20:36:50 2019\n---------------------------------\n\n    Target attribute `outcome'\n\nRead 32 cases (11 attributes) from undefined.data\n\nModel:\n\n  Rule 1: [32 cases, mean 18.37, range 10.4 to 27.3, est err 1.46]\n\n\toutcome = 20.52 - 0.0294 disp + 1.33 drat\n\n\nEvaluation on training data (32 cases):\n\n    Average  |error|               0.71\n    Relative |error|               0.19\n    Correlation coefficient        0.94\n\n\n\tAttribute usage:\n\t  Conds  Model\n\n\t         100%    disp\n\t         100%    drat\n\n\nTime: 0.0 secs\n",
      control = list(
        unbiased = FALSE,
        rules = 100,
        extrapolation = 1,
        sample = 0,
        label = "outcome",
        seed = 27L
      ),
      committees = 1,
      maxd = 2.3,
      dims = c(32L, 10L),
      splits = NULL,
      usage = structure(
        list(
          Conditions = c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
          Model = c(100,
                    100, 0, 0, 0, 0, 0, 0, 0, 0),
          Variable = c(
            "disp",
            "drat",
            "cyl",
            "hp",
            "wt",
            "qsec",
            "vs",
            "am",
            "gear",
            "carb"
          )
        ),
        row.names = c(NA,-10L),
        class = "data.frame"
      ),
      call = as.call(quote(
        cubist.default(
          x = dat[, names(dat) != ".outcome", drop = FALSE],
          y = dat$.outcome,
          committees = 1,
          control = ctrl
        )
      )),
      coefficients = structure(
        list(
          `(Intercept)` = 20.52,
          cyl = NA_real_,
          disp = -0.0294,
          hp = NA_real_,
          drat = 1.33,
          wt = NA_real_,
          qsec = NA_real_,
          vs = NA_real_,
          am = NA_real_,
          gear = NA_real_,
          carb = NA_real_,
          committee = "1",
          rule = "1"
        ),
        row.names = "(Intercept)",
        reshapeWide = list(
          v.names = "value",
          timevar = "var",
          idvar = "tmp",
          times = structure(
            c(1L,
              4L, 5L, 8L, 6L, 11L, 9L, 10L, 2L, 7L, 3L),
            .Label = c(
              "(Intercept)",
              "am",
              "carb",
              "cyl",
              "disp",
              "drat",
              "gear",
              "hp",
              "qsec",
              "vs",
              "wt"
            ),
            class = "factor"
          ),
          varying = structure(
            c(
              "value.(Intercept)",
              "value.cyl",
              "value.disp",
              "value.hp",
              "value.drat",
              "value.wt",
              "value.qsec",
              "value.vs",
              "value.am",
              "value.gear",
              "value.carb"
            ),
            .Dim = c(1L, 11L)
          )
        ),
        class = "data.frame"
      ),
      vars = list(
        all = c(
          "cyl",
          "disp",
          "hp",
          "drat",
          "wt",
          "qsec",
          "vs",
          "am",
          "gear",
          "carb"
        ),
        used = c("drat", "committee",
                 "rule")
      )
    ),
    class = "cubist"
  )

tidypredict::tidypredict_fit(mod)
#> 20.52 + disp * -0.0294 + drat * 1.33

predict(mod, mtcars)
#>  [1] 21.00300 21.00300 22.46530 17.03120 14.12550 17.57580 14.20530 21.11472
#>  [9] 21.59408 20.80616 20.80616 16.49458 16.49458 16.49458 10.54010 10.98600
#> [17] 11.87990 23.63262 24.85132 24.04226 21.91006 14.84160 15.77190 15.19090
#> [25] 12.85640 23.62380 22.87508 22.73816 15.81320 21.07160 16.37880 22.42890

tidypredict::tidypredict_to_column(mtcars, mod)$fit
#>  [1] 21.00300 21.00300 22.46530 17.03120 14.12550 17.57580 14.20530 21.11472
#>  [9] 21.59408 20.80616 20.80616 16.49458 16.49458 16.49458 10.54010 10.98600
#> [17] 11.87990 23.63262 24.85132 24.04226 21.91006 14.84160 15.77190 15.19090
#> [25] 12.85640 23.62380 22.87508 22.73816 15.81320 21.07160 16.37880 22.42890
```

<sup>Created on 2021-09-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>