### PR TITLE
Use `seq2()` to correctly compute indices

### DIFF
--- a/R/model-xgboost.R
+++ b/R/model-xgboost.R
@@ -11,8 +11,8 @@ get_xgb_path <- function(row_id, tree) {
     }
   }
   purrr::map2(
-    path[1:length(path) - 1],
-    path[2:length(path)],
+    path[seq2(1, length(path) - 1)],
+    path[seq2(2, length(path))],
     ~ {
       rb <- tree[.y, ]
       if (rb["Yes"] %in% .x) {


### PR DESCRIPTION
There was a small bug in `get_xgb_path()` related to indexing that has been revealed by the dev purrr revdeps. purrr now recycles using the slightly more strict tidyverse recycling rules, and that has surfaced the issue.

To reproduce the original problem I saw, install dev purrr and run the tests, you should see something like this:

```r
> parse_model(xgb_bin_fit)
Error in `purrr::map()` at tidypredict/R/model-xgboost.R:73:2:
ℹ In index: 43.
Caused by error in `map()` at tidypredict/R/model-xgboost.R:39:2:
ℹ In index: 1.
Caused by error in `purrr::map2()` at tidypredict/R/model-xgboost.R:13:2:
! Can't recycle `.x` (size 0) to match `.y` (size 2).
```

This appeared due to some unfortunate behavior with `:` which can be fixed by switching to `seq2()` from rlang. This mimics what happens when `path` is length 1 in the original code I changed in this PR.

``` r
path <- "foo" # length 1

1:length(path) - 1
#> [1] 0
path[1:length(path) - 1]
#> character(0)

2:length(path)
#> [1] 2 1
path[2:length(path)]
#> [1] NA    "foo"
```

If possible, it would be great if we could get this fixed and sent to CRAN ahead of purrr, as it would make the purrr release a little easier. I think the purrr release is probably still at least 2 weeks out.